### PR TITLE
Added --profile CLI option to support AWS profile-based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,37 @@ uv sync
 uv run lazy-ecs
 ```
 
+## AWS Authentication
+
+lazy-ecs supports multiple ways to authenticate with AWS:
+
+### 1. AWS Profile (--profile flag)
+
+```bash
+lazy-ecs --profile your-profile-name
+```
+
+### 2. Environment Variables
+
+```bash
+export AWS_DEFAULT_PROFILE=your-profile-name
+lazy-ecs
+```
+
+### 3. AWS Vault (existing workflow)
+
+```bash
+aws-vault exec Platform-Test.AWSAdministratorAccess -- lazy-ecs
+```
+
+### 4. Default Credentials Chain
+
+lazy-ecs will automatically use the standard AWS credentials chain:
+
+- Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
+- AWS credentials file (~/.aws/credentials)
+- IAM instance profile (when running on EC2)
+
 ## Features
 
 ### Container-Level Features 🚀

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,46 +1,86 @@
+import sys
 from unittest.mock import Mock, patch
 
-from lazy_ecs import main
+from lazy_ecs import _create_aws_client, main
 
 
-@patch("lazy_ecs.boto3.client")
+@patch("lazy_ecs._create_aws_client")
 @patch("lazy_ecs.ECSNavigator")
 @patch("lazy_ecs.console")
-def test_main_successful_flow(mock_console, mock_navigator_class, mock_boto3_client) -> None:
+def test_main_successful_flow(mock_console, mock_navigator_class, mock_create_client) -> None:
     """Test main function with successful cluster selection."""
     mock_navigator = Mock()
     mock_navigator.select_cluster.return_value = "production"
     mock_navigator_class.return_value = mock_navigator
 
-    main()
+    with patch.object(sys, "argv", ["lazy-ecs"]):
+        main()
 
-    mock_boto3_client.assert_called_once_with("ecs")
+    mock_create_client.assert_called_once_with(None)
     mock_navigator.select_cluster.assert_called_once()
     mock_console.print.assert_any_call("🚀 Welcome to lazy-ecs!", style="bold cyan")
     mock_console.print.assert_any_call("\n✅ Selected cluster: production", style="green")
 
 
-@patch("lazy_ecs.boto3.client")
+@patch("lazy_ecs._create_aws_client")
 @patch("lazy_ecs.ECSNavigator")
 @patch("lazy_ecs.console")
-def test_main_no_cluster_selected(mock_console, mock_navigator_class, _mock_boto3_client) -> None:
+def test_main_no_cluster_selected(mock_console, mock_navigator_class, _mock_create_client) -> None:
     """Test main function when no cluster is selected."""
     mock_navigator = Mock()
     mock_navigator.select_cluster.return_value = None
     mock_navigator_class.return_value = mock_navigator
 
-    main()
+    with patch.object(sys, "argv", ["lazy-ecs"]):
+        main()
 
     mock_console.print.assert_any_call("\n❌ No cluster selected. Goodbye!", style="yellow")
 
 
-@patch("lazy_ecs.boto3.client")
+@patch("lazy_ecs._create_aws_client")
 @patch("lazy_ecs.console")
-def test_main_aws_error(mock_console, mock_boto3_client) -> None:
+def test_main_aws_error(mock_console, mock_create_client) -> None:
     """Test main function with AWS connection error."""
-    mock_boto3_client.side_effect = Exception("No credentials found")
+    mock_create_client.side_effect = Exception("No credentials found")
 
-    main()
+    with patch.object(sys, "argv", ["lazy-ecs"]):
+        main()
 
     mock_console.print.assert_any_call("\n❌ Error: No credentials found", style="red")
     mock_console.print.assert_any_call("Make sure your AWS credentials are configured.", style="dim")
+
+
+@patch("lazy_ecs._create_aws_client")
+@patch("lazy_ecs.ECSNavigator")
+@patch("lazy_ecs.console")
+def test_main_with_profile_argument(_mock_console, mock_navigator_class, mock_create_client) -> None:
+    """Test main function with --profile argument."""
+    mock_navigator = Mock()
+    mock_navigator.select_cluster.return_value = "production"
+    mock_navigator_class.return_value = mock_navigator
+
+    with patch.object(sys, "argv", ["lazy-ecs", "--profile", "my-profile"]):
+        main()
+
+    mock_create_client.assert_called_once_with("my-profile")
+
+
+def test_create_aws_client_without_profile():
+    """Test _create_aws_client without profile returns default client."""
+    with patch("lazy_ecs.boto3.client") as mock_client:
+        _create_aws_client(None)
+        mock_client.assert_called_once_with("ecs")
+
+
+def test_create_aws_client_with_profile():
+    """Test _create_aws_client with profile uses Session."""
+    mock_session = Mock()
+    mock_client = Mock()
+    mock_session.client.return_value = mock_client
+
+    with patch("lazy_ecs.boto3.Session", return_value=mock_session) as mock_session_class:
+        result = _create_aws_client("my-profile")
+
+        mock_session_class.assert_called_once_with(profile_name="my-profile")
+        mock_session.client.assert_called_once_with("ecs")
+        assert result == mock_client


### PR DESCRIPTION
###   Changes

  - Added argparse to parse --profile CLI option
  - Created _create_aws_client() function that supports both profile and default credential chains
  - Updated main function to use new client initialization
  - Added comprehensive test coverage for all authentication methods
  - Updated README with AWS Authentication section

###   Authentication Methods Supported

  1. Profile flag: lazy-ecs --profile your-profile-name
  2. Environment variable: AWS_DEFAULT_PROFILE=your-profile-name lazy-ecs
  3. aws-vault (existing): aws-vault exec Platform-Test.AWSAdministratorAccess -- lazy-ecs
  4. Default credentials chain: Automatically uses AWS credentials from environment variables, ~/.aws/credentials, or IAM instance profiles

###   Technical Details

  - Uses boto3.Session with profile_name when profile specified
  - Falls back to boto3.client() for default credential chain
  - Proper type annotations with mypy_boto3_ecs.ECSClient
  - All existing functionality preserved

Closes #4 