### PR TITLE
[Feature] Support for live container log tailing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+help:
+	@printf "Available commands:\n"
+	@printf "  %-15s --> %s\n" "install" "Install dependencies"
+	@printf "  %-15s --> %s\n" "precminit" "Install pre-commit hooks (runs ruff formatting/linting on commit)"
+	@printf "  %-15s --> %s\n" "run" "Run 'lazy-ecs' CLI (use 'make run PROFILE=<profile-name>' to specify your desired AWS profile)"
+	@printf "  %-15s --> %s\n" "test" "Run tests using 'pytest'"
+	@printf "  %-15s --> %s\n" "format" "Format and lint code (with type annotation enforcement)"
+	@printf "  %-15s --> %s\n" "formatfix" "Format, lint, and fix code (with type annotation enforcement)"
+	@printf "  %-15s --> %s\n" "pyrefly" "Type checking with 'pyrefly'"
+	@printf "  %-15s --> %s\n" "reflyinf" "Auto-add missing type annotations with 'pyrefly'"
+	@printf "  %-15s --> %s\n" "testcov" "Run tests with coverage"
+	@printf "\nTargets that accept arguments:\n"
+	@printf "  %-15s --> %s\n" "test ARGS=\"...\"" "Example: make test ARGS=tests/test_file.py"
+
+install:
+	@uv sync
+
+precminit:
+	@uv run pre-commit install
+
+run:
+	@uv run lazy-ecs $(if $(PROFILE),--profile $(PROFILE),)
+
+test:
+	@uv run pytest $(ARGS)
+
+format:
+	@uv run ruff format
+
+formatfix:
+	@uv run ruff check --fix
+
+pyrefly:
+	@uv run pyrefly check
+
+reflyinf:
+	@uv run pyrefly infer
+
+testcov:
+	@uv run pytest --cov

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ lazy-ecs will automatically use the standard AWS credentials chain:
 ### Container-Level Features 🚀
 
 - ✅ **Container log viewing** - Display recent logs with timestamps from CloudWatch
+- ✅ **Container log live tail viewing** - Display logs live tail with timestamps from CloudWatch
 - ✅ **Basic container details** - Show container name, image, CPU/memory configuration
 - ✅ **Show environment variables & secrets** - Display environment variables and secrets configuration (without exposing secret values)
 - ✅ **Show port mappings** - Display container port configurations and networking
@@ -124,7 +125,7 @@ lazy-ecs will automatically use the standard AWS credentials chain:
 
 - ⬜ **Enhanced log features**:
   - ⬜ Search/filter logs by keywords or time range
-  - ⬜ Follow logs in real-time (tail -f style) - complex UI implementation
+  - ✅ Follow logs in real-time (tail -f style) - complex UI implementation
   - ⬜ Download logs to file
 - ⬜ **Monitoring integration**:
   - ⬜ Show CloudWatch metrics for containers/tasks
@@ -143,6 +144,26 @@ mise install
 ```
 
 ### Setup
+
+Setup and development commands can also be ran with [GNU Make](https://www.gnu.org/software/make/). You can also view available commands with Make using `make`.
+
+```
+Available commands:
+  install         --> Install dependencies
+  precminit       --> Install pre-commit hooks (runs ruff formatting/linting on commit)
+  run             --> Run 'lazy-ecs' CLI (use 'make run PROFILE=<profile-name>' to specify your desired AWS profile)
+  test            --> Run tests using 'pytest'
+  format          --> Format and lint code (with type annotation enforcement)
+  formatfix       --> Format, lint, and fix code (with type annotation enforcement)
+  pyrefly         --> Type checking with 'pyrefly'
+  reflyinf        --> Auto-add missing type annotations with 'pyrefly'
+  testcov         --> Run tests with coverage
+
+Targets that accept arguments:
+  test ARGS="..." --> Example: make test ARGS=tests/test_file.py
+```
+
+Using `uv`
 
 ```bash
 # Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dev-dependencies = [
   "ruff==0.13.0",
   "pre-commit==4.3.0",
   "pyrefly==0.32.0",
-  "boto3-stubs[ecs,logs]==1.40.30",
+  "boto3-stubs[ecs,logs,sts]==1.40.30",
 ]
 
 [tool.ruff]

--- a/src/lazy_ecs/features/task/ui.py
+++ b/src/lazy_ecs/features/task/ui.py
@@ -132,6 +132,10 @@ class TaskUI(BaseUIComponent):
                         "value": f"container_action:show_logs:{container_name}",
                     },
                     {
+                        "name": f"Show logs live tail for container '{container_name}'",
+                        "value": f"container_action:tail_logs:{container_name}",
+                    },
+                    {
                         "name": f"Show environment variables for '{container_name}'",
                         "value": f"container_action:show_env:{container_name}",
                     },

--- a/src/lazy_ecs/ui.py
+++ b/src/lazy_ecs/ui.py
@@ -77,6 +77,10 @@ class ECSNavigator(BaseUIComponent):
         """Display the last N lines of logs for a container."""
         return self._container_ui.show_container_logs(cluster_name, task_arn, container_name, lines)
 
+    def show_container_logs_live_tail(self, cluster_name: str, task_arn: str, container_name: str) -> None:
+        """Stream logs for a container."""
+        return self._container_ui.show_logs_live_tail(cluster_name, task_arn, container_name)
+
     def show_container_environment_variables(self, cluster_name: str, task_arn: str, container_name: str) -> None:
         """Display environment variables for a container."""
         return self._container_ui.show_container_environment_variables(cluster_name, task_arn, container_name)
@@ -110,6 +114,7 @@ def _build_task_feature_choices(containers: list[dict[str, Any]]) -> list[dict[s
     """Build feature menu choices for containers plus navigation options."""
     actions = [
         ("Show tail of logs for container: {name}", "container_action", "show_logs"),
+        ("Show logs live tail for container: {name}", "container_action", "tail_logs"),
         ("Show environment variables for container: {name}", "container_action", "show_env"),
         ("Show secrets for container: {name}", "container_action", "show_secrets"),
         ("Show port mappings for container: {name}", "container_action", "show_ports"),

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -8,7 +8,7 @@ from lazy_ecs.ui import ECSNavigator
 
 
 @pytest.fixture
-def mock_ecs_service():
+def mock_ecs_service() -> Mock:
     """Create a mock ECS service."""
     return Mock()
 
@@ -149,6 +149,7 @@ def test_container_methods_delegate_to_container_ui(mock_ecs_service) -> None:
 
     # Mock all ContainerUI methods
     navigator._container_ui.show_container_logs = Mock()
+    navigator._container_ui.show_logs_live_tail = Mock()
     navigator._container_ui.show_container_environment_variables = Mock()
     navigator._container_ui.show_container_secrets = Mock()
     navigator._container_ui.show_container_port_mappings = Mock()
@@ -156,6 +157,7 @@ def test_container_methods_delegate_to_container_ui(mock_ecs_service) -> None:
 
     # Test delegation
     navigator.show_container_logs("cluster", "task", "container", 100)
+    navigator.show_container_logs_live_tail("cluster", "task", "container")
     navigator.show_container_environment_variables("cluster", "task", "container")
     navigator.show_container_secrets("cluster", "task", "container")
     navigator.show_container_port_mappings("cluster", "task", "container")
@@ -163,6 +165,7 @@ def test_container_methods_delegate_to_container_ui(mock_ecs_service) -> None:
 
     # Verify delegation
     navigator._container_ui.show_container_logs.assert_called_once_with("cluster", "task", "container", 100)
+    navigator._container_ui.show_logs_live_tail.assert_called_once_with("cluster", "task", "container")
     navigator._container_ui.show_container_environment_variables.assert_called_once_with("cluster", "task", "container")
     navigator._container_ui.show_container_secrets.assert_called_once_with("cluster", "task", "container")
     navigator._container_ui.show_container_port_mappings.assert_called_once_with("cluster", "task", "container")
@@ -192,12 +195,14 @@ def test_build_task_feature_choices() -> None:
 
     # Check container actions are present
     assert "Show tail of logs for container: web" in choice_names
+    assert "Show logs live tail for container: web" in choice_names
     assert "Show environment variables for container: web" in choice_names
     assert "Show secrets for container: web" in choice_names
     assert "Show port mappings for container: web" in choice_names
     assert "Show volume mounts for container: web" in choice_names
 
     assert "Show tail of logs for container: sidecar" in choice_names
+    assert "Show logs live tail for container: sidecar" in choice_names
     assert "Show environment variables for container: sidecar" in choice_names
     assert "Show secrets for container: sidecar" in choice_names
     assert "Show port mappings for container: sidecar" in choice_names
@@ -213,5 +218,5 @@ def test_build_task_feature_choices() -> None:
     assert "navigation:back" in choice_values
     assert "navigation:exit" in choice_values
 
-    # Total: 5 actions x 2 containers + 2 navigation = 12
-    assert len(choices) == 12
+    # Total: 6 actions x 2 containers + 2 navigation = 14
+    assert len(choices) == 14

--- a/uv.lock
+++ b/uv.lock
@@ -37,6 +37,9 @@ ecs = [
 logs = [
     { name = "mypy-boto3-logs" },
 ]
+sts = [
+    { name = "mypy-boto3-sts" },
+]
 
 [[package]]
 name = "botocore"
@@ -388,7 +391,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "boto3-stubs", extra = ["ecs", "logs"] },
+    { name = "boto3-stubs", extra = ["ecs", "logs", "sts"] },
     { name = "moto" },
     { name = "pre-commit" },
     { name = "pyrefly" },
@@ -407,7 +410,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "boto3-stubs", extras = ["ecs", "logs"], specifier = "==1.40.30" },
+    { name = "boto3-stubs", extras = ["ecs", "logs", "sts"], specifier = "==1.40.30" },
     { name = "moto", extras = ["ecs"], specifier = "==5.1.12" },
     { name = "pre-commit", specifier = "==4.3.0" },
     { name = "pyrefly", specifier = "==0.32.0" },
@@ -528,6 +531,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/41/39/04226e710cc4682987f6ca0537b0d41bd20ceca9926947bb3a26b3ae030f/mypy_boto3_logs-1.40.0.tar.gz", hash = "sha256:780648820c4fe8c2453a39a8044443435b4969f69ea39ce538ba5b2225cfd513", size = 46369, upload-time = "2025-07-31T19:45:33.794Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/12/c66f68dd01675ca76388b678b42c2d4a2aac0c483015614a43026339c63b/mypy_boto3_logs-1.40.0-py3-none-any.whl", hash = "sha256:70c8d13772cd9ea0924508b8e16db83f22b043e2897ff881e9a6d0b282664634", size = 52243, upload-time = "2025-07-31T19:45:31.47Z" },
+]
+
+[[package]]
+name = "mypy-boto3-sts"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/32/8dce999ed05c797000ce70287f3e82025a98514781c303c7f8fe42f7b327/mypy_boto3_sts-1.40.0.tar.gz", hash = "sha256:eb55e50960ae6194d09488464c302196392df712a6a5f4308b6a0e24244cfd5c", size = 16577, upload-time = "2025-07-31T19:52:23.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/f8/38dae2983d72ea4fff75b235d42d3b1ecad407e0136f4951bfd9016ecaea/mypy_boto3_sts-1.40.0-py3-none-any.whl", hash = "sha256:fff731694cab2474bf7e7d3344b049b4ac0272d76b72fc4f7e4ae543ead8a5e6", size = 20192, upload-time = "2025-07-31T19:52:21.353Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Added support for live container log tailing

The purpose of this PR is to introduce live log tailing for a selected container, providing the user with real-time insight into your running containers for debugging & increased observability .

## Features
- Added a `Makefile` to streamline dependency installations, pre-commit hook installs, testing with `pytest`, and formatting/linting with `ruff`
    - Updated `README` documentation to cover additional usage with `make`
- Introduced `show_logs_live_tail()` UI behavior to continuously stream real-time logs for a target container
    - Updated dependencies with `sts` package to extrapolate a given AWS Account ID when building the target log group ARN to be tailed
- Updated test cases to include additional UI prompt for real-time log tailing container option 