### PR TITLE
Add Docker as an installation method

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,60 @@
+name: Build and Push Docker Image
+
+on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - main
+    paths:
+      - "Dockerfile"
+      - "src/**"
+      - "pyproject.toml"
+  workflow_dispatch:
+
+env:
+  DOCKER_HUB_USERNAME: vertti
+  IMAGE_NAME: lazy-ecs
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_HUB_USERNAME }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Build stage
+FROM python:3.13-slim as builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Set working directory
+WORKDIR /app
+
+# Copy project files
+COPY pyproject.toml README.md ./
+COPY src ./src
+
+# Build the package
+RUN uv build --wheel
+
+# Runtime stage
+FROM python:3.13-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN useradd -m -s /bin/bash lazyecs
+
+# Set working directory
+WORKDIR /app
+
+# Copy wheel from builder
+COPY --from=builder /app/dist/*.whl /tmp/
+
+# Install the package
+RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
+
+# Switch to non-root user
+USER lazyecs
+
+# Set entrypoint
+ENTRYPOINT ["lazy-ecs"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,12 @@ COPY --from=builder /app/dist/*.whl /tmp/
 # Install the package
 RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
 
+# Copy entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 # Switch to non-root user
 USER lazyecs
 
 # Set entrypoint
-ENTRYPOINT ["lazy-ecs"]
-CMD ["--help"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ The AWS ECS web console is confusing to navigate, with multiple clicks through d
 
 ## Installation
 
+### Homebrew
+
+```bash
+# Add the tap
+brew tap vertti/lazy-ecs
+
+# Install lazy-ecs
+brew install lazy-ecs
+
+# Run it
+lazy-ecs
+```
+
 ### pipx
 
 [pipx](https://pipx.pypa.io/) installs Python CLI tools in isolated environments:
@@ -35,17 +48,33 @@ pipx install lazy-ecs
 lazy-ecs
 ```
 
-### Homebrew
+### Docker
+
+Run lazy-ecs using Docker without installing Python:
 
 ```bash
-# Add the tap
-brew tap vertti/lazy-ecs
+# Run with AWS credentials from your environment
+docker run -it --rm \
+  -v ~/.aws:/home/lazyecs/.aws:ro \
+  -e AWS_PROFILE \
+  -e AWS_DEFAULT_REGION \
+  vertti/lazy-ecs
 
-# Install lazy-ecs
-brew install lazy-ecs
+# Or with specific AWS environment variables
+docker run -it --rm \
+  -e AWS_ACCESS_KEY_ID \
+  -e AWS_SECRET_ACCESS_KEY \
+  -e AWS_SESSION_TOKEN \
+  -e AWS_DEFAULT_REGION \
+  vertti/lazy-ecs
 
-# Run it
-lazy-ecs
+# With aws-vault
+aws-vault exec your-profile -- docker run -it --rm \
+  -e AWS_ACCESS_KEY_ID \
+  -e AWS_SECRET_ACCESS_KEY \
+  -e AWS_SESSION_TOKEN \
+  -e AWS_DEFAULT_REGION \
+  vertti/lazy-ecs
 ```
 
 ### From Source

--- a/README.md
+++ b/README.md
@@ -53,28 +53,31 @@ lazy-ecs
 Run lazy-ecs using Docker without installing Python:
 
 ```bash
-# Run with AWS credentials from your environment
-docker run -it --rm \
-  -v ~/.aws:/home/lazyecs/.aws:ro \
-  -e AWS_PROFILE \
-  -e AWS_DEFAULT_REGION \
-  vertti/lazy-ecs
-
-# Or with specific AWS environment variables
-docker run -it --rm \
-  -e AWS_ACCESS_KEY_ID \
-  -e AWS_SECRET_ACCESS_KEY \
-  -e AWS_SESSION_TOKEN \
-  -e AWS_DEFAULT_REGION \
-  vertti/lazy-ecs
-
-# With aws-vault
+# With aws-vault (temporary credentials)
 aws-vault exec your-profile -- docker run -it --rm \
-  -e AWS_ACCESS_KEY_ID \
-  -e AWS_SECRET_ACCESS_KEY \
-  -e AWS_SESSION_TOKEN \
-  -e AWS_DEFAULT_REGION \
+  -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e AWS_REGION \
   vertti/lazy-ecs
+
+# With IAM credentials (long-lived)
+docker run -it --rm \
+  -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_REGION \
+  vertti/lazy-ecs
+
+# With AWS credentials file
+docker run -it --rm -v ~/.aws:/home/lazyecs/.aws:ro vertti/lazy-ecs
+
+# With specific profile
+docker run -it --rm -v ~/.aws:/home/lazyecs/.aws:ro -e AWS_PROFILE=your-profile vertti/lazy-ecs
+```
+
+**Pro tip:** Create an alias for easier usage:
+
+```bash
+# Add to your ~/.bashrc or ~/.zshrc
+alias lazy-ecs-docker='docker run -it --rm -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e AWS_REGION vertti/lazy-ecs'
+
+# Then use with aws-vault
+aws-vault exec your-profile -- lazy-ecs-docker
 ```
 
 ### From Source

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Docker entrypoint that automatically handles AWS credentials
+
+# Normalize region settings - boto3 uses AWS_DEFAULT_REGION
+if [ -n "$AWS_REGION" ] && [ -z "$AWS_DEFAULT_REGION" ]; then
+    export AWS_DEFAULT_REGION="$AWS_REGION"
+fi
+
+# Check if we have AWS credentials in environment
+if [ -n "$AWS_ACCESS_KEY_ID" ] || [ -n "$AWS_PROFILE" ] || [ -f "$HOME/.aws/credentials" ]; then
+    # Credentials are available, run lazy-ecs
+    exec lazy-ecs "$@"
+else
+    echo "❌ No AWS credentials found!"
+    echo ""
+    echo "Please provide AWS credentials using one of these methods:"
+    echo ""
+    echo "1. Mount your AWS config:"
+    echo "   docker run -it --rm -v ~/.aws:/home/lazyecs/.aws:ro vertti/lazy-ecs"
+    echo ""
+    echo "2. With aws-vault (temporary credentials):"
+    echo "   aws-vault exec your-profile -- docker run -it --rm \\"
+    echo "     -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e AWS_REGION \\"
+    echo "     vertti/lazy-ecs"
+    echo ""
+    echo "3. With IAM credentials (long-lived):"
+    echo "   docker run -it --rm \\"
+    echo "     -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_REGION \\"
+    echo "     vertti/lazy-ecs"
+    echo ""
+    exit 1
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lazy-ecs"
-version = "0.3.1"
+version = "0.3.2"
 description = "A CLI tool for working with AWS services"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -381,7 +381,7 @@ wheels = [
 
 [[package]]
 name = "lazy-ecs"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
This PR adds Docker containerization for lazy-ecs to enable using with zero deps or installation

###   Docker Support

  - Dockerfile: Multi-stage build using Python 3.13-slim for a minimal, secure image
  - Automated Publishing: GitHub Actions workflow to build and push multi-platform images (linux/amd64, linux/arm64) to Docker Hub on releases
  - Smart Entrypoint: Automatically handles AWS credential detection and region normalization
  - Security: Runs as non-root user (lazyecs) for better container security

###   Enhanced Distribution

  - Multiple Installation Options: Now supports Homebrew, pipx, Docker, and source installation