### PR TITLE
Fix: Handle AWS ECS 10-service limit in describe_services

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lazy-ecs"
-version = "0.6.0"
+version = "0.7.0"
 description = "A CLI tool for working with AWS services"
 readme = "README.md"
 authors = [

--- a/src/lazy_ecs/core/utils.py
+++ b/src/lazy_ecs/core/utils.py
@@ -8,7 +8,7 @@ import sys
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager, suppress
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from rich.console import Console
 from rich.spinner import Spinner
@@ -78,6 +78,12 @@ def show_spinner() -> Iterator[None]:
     spinner = Spinner("dots", style="cyan")
     with console.status(spinner):
         yield
+
+
+def batch_items(items: list[Any], batch_size: int) -> Iterator[list[Any]]:
+    """Split a list into batches of specified size."""
+    for i in range(0, len(items), batch_size):
+        yield items[i : i + batch_size]
 
 
 def paginate_aws_list(

--- a/src/lazy_ecs/features/service/service.py
+++ b/src/lazy_ecs/features/service/service.py
@@ -31,10 +31,11 @@ class ServiceService(BaseAWSService):
         if not service_names:
             return []
 
-        all_services = []
-        for batch in batch_items(service_names, 10):
-            response = self.ecs_client.describe_services(cluster=cluster_name, services=batch)
-            all_services.extend(response.get("services", []))
+        all_services = [
+            service
+            for batch in batch_items(service_names, 10)
+            for service in self.ecs_client.describe_services(cluster=cluster_name, services=batch).get("services", [])
+        ]
 
         return [_create_service_info(service) for service in all_services]
 

--- a/tests/test_aws_service.py
+++ b/tests/test_aws_service.py
@@ -290,9 +290,8 @@ def test_get_service_info_with_more_than_10_services():
         service_info = service.get_service_info("production")
 
         assert len(service_info) == 15
-        service_names = [info["name"] for info in service_info]
-        for i in range(15):
-            assert any(f"service-{i:02d}" in name for name in service_names)
+        service_names = {info["name"] for info in service_info}
+        assert all(any(f"service-{i:02d}" in name for name in service_names) for i in range(15))
 
 
 def test_get_tasks(ecs_client_with_tasks) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,57 +4,36 @@ from lazy_ecs.core.utils import batch_items
 
 
 def test_batch_items_basic():
-    items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    batches = list(batch_items(items, 3))
+    batches = list(batch_items([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3))
 
-    assert len(batches) == 4
-    assert batches[0] == [1, 2, 3]
-    assert batches[1] == [4, 5, 6]
-    assert batches[2] == [7, 8, 9]
-    assert batches[3] == [10]
+    assert batches == [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]]
 
 
 def test_batch_items_exact_fit():
-    items = [1, 2, 3, 4, 5, 6]
-    batches = list(batch_items(items, 3))
+    batches = list(batch_items([1, 2, 3, 4, 5, 6], 3))
 
-    assert len(batches) == 2
-    assert batches[0] == [1, 2, 3]
-    assert batches[1] == [4, 5, 6]
+    assert batches == [[1, 2, 3], [4, 5, 6]]
 
 
 def test_batch_items_single_batch():
-    items = [1, 2, 3]
-    batches = list(batch_items(items, 10))
+    batches = list(batch_items([1, 2, 3], 10))
 
-    assert len(batches) == 1
-    assert batches[0] == [1, 2, 3]
+    assert batches == [[1, 2, 3]]
 
 
 def test_batch_items_empty_list():
-    items = []
-    batches = list(batch_items(items, 5))
+    batches = list(batch_items([], 5))
 
-    assert len(batches) == 0
+    assert batches == []
 
 
 def test_batch_items_size_one():
-    items = [1, 2, 3, 4, 5]
-    batches = list(batch_items(items, 1))
+    batches = list(batch_items([1, 2, 3, 4, 5], 1))
 
-    assert len(batches) == 5
-    assert batches[0] == [1]
-    assert batches[1] == [2]
-    assert batches[2] == [3]
-    assert batches[3] == [4]
-    assert batches[4] == [5]
+    assert batches == [[1], [2], [3], [4], [5]]
 
 
 def test_batch_items_strings():
-    items = ["a", "b", "c", "d", "e", "f", "g"]
-    batches = list(batch_items(items, 3))
+    batches = list(batch_items(["a", "b", "c", "d", "e", "f", "g"], 3))
 
-    assert len(batches) == 3
-    assert batches[0] == ["a", "b", "c"]
-    assert batches[1] == ["d", "e", "f"]
-    assert batches[2] == ["g"]
+    assert batches == [["a", "b", "c"], ["d", "e", "f"], ["g"]]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,60 @@
+"""Tests for utility functions."""
+
+from lazy_ecs.core.utils import batch_items
+
+
+def test_batch_items_basic():
+    items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    batches = list(batch_items(items, 3))
+
+    assert len(batches) == 4
+    assert batches[0] == [1, 2, 3]
+    assert batches[1] == [4, 5, 6]
+    assert batches[2] == [7, 8, 9]
+    assert batches[3] == [10]
+
+
+def test_batch_items_exact_fit():
+    items = [1, 2, 3, 4, 5, 6]
+    batches = list(batch_items(items, 3))
+
+    assert len(batches) == 2
+    assert batches[0] == [1, 2, 3]
+    assert batches[1] == [4, 5, 6]
+
+
+def test_batch_items_single_batch():
+    items = [1, 2, 3]
+    batches = list(batch_items(items, 10))
+
+    assert len(batches) == 1
+    assert batches[0] == [1, 2, 3]
+
+
+def test_batch_items_empty_list():
+    items = []
+    batches = list(batch_items(items, 5))
+
+    assert len(batches) == 0
+
+
+def test_batch_items_size_one():
+    items = [1, 2, 3, 4, 5]
+    batches = list(batch_items(items, 1))
+
+    assert len(batches) == 5
+    assert batches[0] == [1]
+    assert batches[1] == [2]
+    assert batches[2] == [3]
+    assert batches[3] == [4]
+    assert batches[4] == [5]
+
+
+def test_batch_items_strings():
+    items = ["a", "b", "c", "d", "e", "f", "g"]
+    batches = list(batch_items(items, 3))
+
+    assert len(batches) == 3
+    assert batches[0] == ["a", "b", "c"]
+    assert batches[1] == ["d", "e", "f"]
+    assert batches[2] == ["g"]

--- a/uv.lock
+++ b/uv.lock
@@ -384,7 +384,7 @@ wheels = [
 
 [[package]]
 name = "lazy-ecs"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
### Problem
Clusters with more than 10 services were crashing with the error:
Error: An error occurred (InvalidParameterException) when calling the DescribeServices operation: service names can have at most 10 items.

AWS ECS `describe_services` API has a hard limit of 10 services per call, but the code was attempting to describe all services in a single request.

### Solution
Implemented batching for `describe_services` calls to process services in groups of 10:

1. **Added `batch_items()` utility function** (`src/lazy_ecs/core/utils.py`)
   - Generic helper to split lists into fixed-size chunks
   - Reusable for other AWS API limits

2. **Updated `ServiceService.get_service_info()`** (`src/lazy_ecs/features/service/service.py`)
   - Batches service names into groups of 10
   - Makes multiple `describe_services` calls as needed
   - Aggregates results from all batches
   - Uses Pythonic nested list comprehension for clean implementation

3. **Added comprehensive tests**
   - `test_batch_items_*`: Tests for utility function with various edge cases
   - `test_get_service_info_with_more_than_10_services`: Verifies batching works correctly with 15 services
   - All existing tests continue to pass

Closes #37 